### PR TITLE
Replace hadcoded card numbers with enums

### DIFF
--- a/src/test/java/com/rbkmoney/proxy/mocketbank/configuration/DeadlineTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/configuration/DeadlineTest.java
@@ -5,6 +5,7 @@ import com.rbkmoney.damsel.domain.*;
 import com.rbkmoney.damsel.proxy_provider.Shop;
 import com.rbkmoney.damsel.proxy_provider.*;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Visa;
 import com.rbkmoney.woody.api.flow.error.WRuntimeException;
 import com.rbkmoney.woody.api.flow.error.WUnavailableResultException;
 import com.rbkmoney.woody.thrift.impl.http.THSpawnClientBuilder;
@@ -85,7 +86,7 @@ public class DeadlineTest {
     }
 
     private void mockCdsBean() {
-        Mockito.when(cds.getCardData((RecurrentTokenContext) any())).thenReturn(TestData.createCardDataProxyModel("4012888888881881"));
+        Mockito.when(cds.getCardData((RecurrentTokenContext) any())).thenReturn(TestData.createCardDataProxyModel(Visa.SUCCESS_3DS.getCardNumber()));
     }
 
     private void deadlineTest() throws TException {

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerFailIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerFailIntegrationTest.java
@@ -4,6 +4,9 @@ import com.rbkmoney.damsel.cds.CardData;
 import com.rbkmoney.damsel.domain.BankCard;
 import com.rbkmoney.damsel.proxy_provider.PaymentProxyResult;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Mastercard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Visa;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -30,21 +33,21 @@ public class MocketBankServerHandlerFailIntegrationTest extends IntegrationTest 
 
     @Test
     public void testProcessPaymentFail() throws TException {
-        String[] cards = {
-                "4000000000000002",
-                "5100000000000412",
-                "4222222222222220",
-                "5100000000000511",
-                "4003830171874018",
-                "5496198584584769",
-                "4000000000000069",
-                "5105105105105100",
-                "4111110000000112",
-                "5124990000000002",
+        TestCard[] cards = {
+                Visa.INSUFFICIENT_FUNDS,
+                Mastercard.INSUFFICIENT_FUNDS,
+                Visa.INVALID_CARD,
+                Mastercard.INVALID_CARD,
+                Visa.CVV_MATCH_FAIL,
+                Mastercard.CVV_MATCH_FAIL,
+                Visa.EXPIRED,
+                Mastercard.EXPIRED,
+                Visa.UNKNOWN_FAILURE,
+                Mastercard.UNKNOWN_FAILURE
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPaymentFail(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerFailWith3DSIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerFailWith3DSIntegrationTest.java
@@ -9,6 +9,9 @@ import com.rbkmoney.proxy.mocketbank.TestData;
 import com.rbkmoney.proxy.mocketbank.utils.Converter;
 import com.rbkmoney.proxy.mocketbank.utils.mocketbank.constant.MpiEnrollmentStatus;
 import com.rbkmoney.proxy.mocketbank.utils.mocketbank.constant.MpiTransactionStatus;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Mastercard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Visa;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -41,15 +44,15 @@ public class MocketBankServerHandlerFailWith3DSIntegrationTest extends Integrati
 
     @Test
     public void testProcessPaymentFail() throws TException, IOException {
-        String[] cards = {
-                "4987654321098769",
-                "5123456789012346",
-                "4342561111111118",
-                "5112000200000002",
+        TestCard[] cards = {
+                Visa.FAILURE_3DS,
+                Mastercard.FAILURE_3DS,
+                Visa.TIMEOUT_3DS,
+                Mastercard.TIMEOUT_3DS
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPaymentFail(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerRecurrent3DSSuccessIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerRecurrent3DSSuccessIntegrationTest.java
@@ -7,6 +7,9 @@ import com.rbkmoney.proxy.mocketbank.TestData;
 import com.rbkmoney.proxy.mocketbank.utils.Converter;
 import com.rbkmoney.proxy.mocketbank.utils.mocketbank.constant.MpiEnrollmentStatus;
 import com.rbkmoney.proxy.mocketbank.utils.mocketbank.constant.MpiTransactionStatus;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Mastercard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Visa;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -41,13 +44,13 @@ public class MocketBankServerHandlerRecurrent3DSSuccessIntegrationTest extends I
 
     @Test
     public void testProcessPaymentSuccess() throws TException, IOException {
-        String[] cards = {
-                "4012888888881881",
-                "5169147129584558",
+        TestCard[] cards = {
+                Visa.SUCCESS_3DS,
+                Mastercard.SUCCESS_3DS
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPayment(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerRecurrentSuccessIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerRecurrentSuccessIntegrationTest.java
@@ -4,6 +4,7 @@ import com.rbkmoney.damsel.cds.CardData;
 import com.rbkmoney.damsel.domain.BankCard;
 import com.rbkmoney.damsel.proxy_provider.*;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -34,14 +35,15 @@ public class MocketBankServerHandlerRecurrentSuccessIntegrationTest extends Inte
 
     @Test
     public void testProcessPaymentSuccess() throws TException, IOException {
-        String[] cards = {
-                "4242424242424242",
-                "5555555555554444",
-                "586824160825533338",
+        TestCard[] cards = {
+                Visa.SUCCESS,
+                Mastercard.SUCCESS,
+                Maestro.SUCCESS,
+                Mir.SUCCESS
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPayment(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessApplePayntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessApplePayntegrationTest.java
@@ -5,6 +5,8 @@ import com.rbkmoney.damsel.domain.BankCard;
 import com.rbkmoney.damsel.domain.BankCardTokenProvider;
 import com.rbkmoney.damsel.proxy_provider.PaymentProxyResult;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Visa;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -31,12 +33,12 @@ public class MocketBankServerHandlerSuccessApplePayntegrationTest extends Integr
 
     @Test
     public void testProcessPaymentFail() throws TException {
-        String[] cards = {
-                "5000000000000009",
+        TestCard[] cards = {
+                Visa.APPLE_PAY_FAILURE
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPayment(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessGooglePayIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessGooglePayIntegrationTest.java
@@ -5,6 +5,8 @@ import com.rbkmoney.damsel.domain.BankCard;
 import com.rbkmoney.damsel.domain.BankCardTokenProvider;
 import com.rbkmoney.damsel.proxy_provider.PaymentProxyResult;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Mastercard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -31,12 +33,12 @@ public class MocketBankServerHandlerSuccessGooglePayIntegrationTest extends Inte
 
     @Test
     public void testProcessPaymentSuccess() throws TException {
-        String[] cards = {
-                "2222990905257051",
+        TestCard[] cards = {
+                Mastercard.GOOGLE_PAY_SUCCESS,
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPayment(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessIntegrationTest.java
@@ -5,6 +5,7 @@ import com.rbkmoney.damsel.domain.BankCard;
 import com.rbkmoney.damsel.domain.TransactionInfo;
 import com.rbkmoney.damsel.proxy_provider.PaymentProxyResult;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -33,15 +34,15 @@ public class MocketBankServerHandlerSuccessIntegrationTest extends IntegrationTe
 
     @Test
     public void testProcessPaymentSuccess() throws TException {
-        String[] cards = {
-                "4242424242424242",
-                "5555555555554444",
-                "586824160825533338",
-                "2201382000000013",
+        TestCard[] cards = {
+                Visa.SUCCESS,
+                Mastercard.SUCCESS,
+                Maestro.SUCCESS,
+                Mir.SUCCESS
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPaymentSuccess(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessSamsungPayIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessSamsungPayIntegrationTest.java
@@ -5,6 +5,8 @@ import com.rbkmoney.damsel.domain.BankCard;
 import com.rbkmoney.damsel.domain.BankCardTokenProvider;
 import com.rbkmoney.damsel.proxy_provider.PaymentProxyResult;
 import com.rbkmoney.proxy.mocketbank.TestData;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Mastercard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -31,12 +33,12 @@ public class MocketBankServerHandlerSuccessSamsungPayIntegrationTest extends Int
 
     @Test
     public void testProcessPaymentSuccess() throws TException {
-        String[] cards = {
-                "2223577120017656",
+        TestCard[] cards = {
+                Mastercard.SAMSUNG_PAY_SUCCESS,
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPayment(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessWith3DSIntegrationTest.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/handler/MocketBankServerHandlerSuccessWith3DSIntegrationTest.java
@@ -9,6 +9,9 @@ import com.rbkmoney.proxy.mocketbank.TestData;
 import com.rbkmoney.proxy.mocketbank.utils.Converter;
 import com.rbkmoney.proxy.mocketbank.utils.mocketbank.constant.MpiEnrollmentStatus;
 import com.rbkmoney.proxy.mocketbank.utils.mocketbank.constant.MpiTransactionStatus;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Mastercard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.TestCard;
+import com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards.Visa;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -43,13 +46,13 @@ public class MocketBankServerHandlerSuccessWith3DSIntegrationTest extends Integr
 
     @Test
     public void testProcessPaymentSuccess() throws TException, IOException {
-        String[] cards = {
-                "4012888888881881",
-                "5169147129584558",
+        TestCard[] cards = {
+                Visa.SUCCESS_3DS,
+                Mastercard.SUCCESS_3DS
         };
 
-        for (String card : cards) {
-            CardData cardData = createCardData(card);
+        for (TestCard card : cards) {
+            CardData cardData = createCardData(card.getCardNumber());
             processPaymentSuccess(cardData);
         }
     }

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Maestro.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Maestro.java
@@ -1,0 +1,12 @@
+package com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Maestro implements TestCard {
+    SUCCESS("586824160825533338");
+
+    private final String cardNumber;
+}

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Mastercard.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Mastercard.java
@@ -1,0 +1,24 @@
+package com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Mastercard implements TestCard {
+    SUCCESS("5555555555554444"),
+    SUCCESS_3DS("5169147129584558"),
+    FAILURE_3DS("5123456789012346"),
+    TIMEOUT_3DS("5112000200000002"),
+    INSUFFICIENT_FUNDS("5100000000000412"),
+    INVALID_CARD("5100000000000511"),
+    CVV_MATCH_FAIL("5496198584584769"),
+    EXPIRED("5105105105105100"),
+    UNKNOWN_FAILURE("5124990000000002"),
+    GOOGLE_PAY_FAILURE("2222405343248877"),
+    GOOGLE_PAY_SUCCESS("2222990905257051"),
+    SAMSUNG_PAY_FAILURE("2223007648726984"),
+    SAMSUNG_PAY_SUCCESS("2223577120017656");
+
+    private final String cardNumber;
+}

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Mir.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Mir.java
@@ -1,0 +1,12 @@
+package com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Mir implements TestCard {
+    SUCCESS("2201382000000013");
+
+    private final String cardNumber;
+}

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/TestCard.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/TestCard.java
@@ -1,0 +1,5 @@
+package com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards;
+
+public interface TestCard {
+    String getCardNumber();
+}

--- a/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Visa.java
+++ b/src/test/java/com/rbkmoney/proxy/mocketbank/utils/p2p/constant/testcards/Visa.java
@@ -1,0 +1,22 @@
+package com.rbkmoney.proxy.mocketbank.utils.p2p.constant.testcards;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Visa implements TestCard {
+    SUCCESS("4242424242424242"),
+    SUCCESS_3DS("4012888888881881"),
+    FAILURE_3DS("4987654321098769"),
+    TIMEOUT_3DS("4342561111111118"),
+    INSUFFICIENT_FUNDS("4000000000000002"),
+    INVALID_CARD("4222222222222220"),
+    CVV_MATCH_FAIL("4003830171874018"),
+    EXPIRED("4000000000000069"),
+    UNKNOWN_FAILURE("4111110000000112"),
+    APPLE_PAY_FAILURE("5000000000000009"),
+    APPLE_PAY_SUCCESS("4300000000000777");
+
+    private final String cardNumber;
+}


### PR DESCRIPTION
 Мне показалось, что хардкод номеров карт в тестах выглядит очень неочевидно, так что присвоил карточкам человекочитаемые описания